### PR TITLE
Remove azurerm provider

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,4 +1,0 @@
-provider "azurerm" {
-  features {}
-  skip_provider_registration = true
-}


### PR DESCRIPTION
> A module intended to be called by one or more other modules must not contain any provider blocks.

https://developer.hashicorp.com/terraform/language/modules/develop/providers