### PR TITLE
Time managed key vault expiry

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,14 @@ module "data_protection" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.9 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.13.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.0 |
+| <a name="provider_time"></a> [time](#provider\_time) | ~> 0.13.0 |
 
 ## Resources
 
@@ -56,6 +58,7 @@ module "data_protection" {
 | [azurerm_private_endpoint.key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_role_assignment.key_user_role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_subnet.key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
+| [time_static.key_expiration_date](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/static) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_key_vault.data_protection](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 | [azurerm_virtual_network.vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |

--- a/data.tf
+++ b/data.tf
@@ -11,3 +11,10 @@ data "azurerm_virtual_network" "vnet" {
   name                = local.vnet_name
   resource_group_name = local.resource_group_name
 }
+
+resource "time_static" "key_expiration_date" {
+  triggers = {
+    # Save the time when Key Vault is built
+    key_vault_id = local.key_vault.id
+  }
+}

--- a/key-vault.tf
+++ b/key-vault.tf
@@ -44,5 +44,9 @@ resource "azurerm_key_vault_key" "data_protection" {
     notify_before_expiry = "P29D"
   }
 
-  expiration_date = local.year_from_now
+  expiration_date = local.key_expiration_date
+
+  lifecycle {
+    ignore_changes = [expiration_date]
+  }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -6,12 +6,11 @@ locals {
   container_identity_principal_id = var.data_protection_container_identity_principal_id
   subnet_prefix                   = var.data_protection_key_vault_subnet_prefix
   key_vault_access_ipv4           = var.data_protection_key_vault_access_ipv4
+  key_expiration_date             = timeadd(time_static.key_expiration_date.id, "${local.key_expiry_years * 8760}h")
   resource_group_name             = var.data_protection_resource_group_name
   vnet_name                       = var.data_protection_vnet_name == "" ? "${local.resource_prefix}default" : var.data_protection_vnet_name
   azure_location                  = var.data_protection_azure_location
   key_expiry_years                = var.data_protection_key_expiry_years
-  timestamp_parts                 = regex("^(?P<year>\\d+)(?P<remainder>-.*)$", timestamp())
-  year_from_now                   = format("%d%s", local.timestamp_parts.year + local.key_expiry_years, local.timestamp_parts.remainder)
   tags                            = var.data_protection_tags
   enable_diagnostic_setting       = var.data_protection_enable_diagnostic_setting
   enable_log_analytics_workspace  = var.data_protection_diagnostic_log_analytics_workspace_id == "" ? var.data_protection_enable_log_analytics_workspace : false

--- a/versions.tf
+++ b/versions.tf
@@ -6,5 +6,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
+
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.13.0"
+    }
   }
 }


### PR DESCRIPTION
**What?**
Where previously we were calculating a time offset from `now()`, we are now using a static time reference held in tf state.

**Why?**
The problem we were facing was that each time a new TF plan was run, a new expiry date was being calculated from `now` causing the Key Vault Key to be destroyed and rebuilt each time an apply happened.

I have also added an ignore lifecycle rule because the key should auto-rotate 30d before expiration, and i probably wouldn't want TF to rebuild the key because the expiration got moved on.